### PR TITLE
Fix android animation (#5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/AnimatedEllipsis.js",
   "scripts": {
     "build": "babel src/ -d dist",
-    "prepublish": "npm run build"
+    "prepare": "npm run build"
   },
   "author": "Casey Brant <casey@adorable.io>",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-animated-ellipsis",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A simple, customizable animated dots component for use in React Native apps. Ideal for loading screens.",
   "main": "dist/AnimatedEllipsis.js",
   "scripts": {

--- a/src/AnimatedEllipsis.js
+++ b/src/AnimatedEllipsis.js
@@ -1,5 +1,5 @@
 import React, { Component }    from 'react';
-import { Text, Animated }      from 'react-native';
+import { Text, Animated, View, StyleSheet }      from 'react-native';
 import PropTypes               from 'prop-types';
 
 
@@ -71,14 +71,24 @@ export default class AnimatedEllipsis extends Component {
 
   render () {
     let dots = this._animation_state.dot_opacities.map((o, i) =>
-      <Animated.Text key={i} style={{ opacity: o }}> .</Animated.Text>
+      <Animated.Text key={i} style={[this.props.style, { opacity: o }]}>
+        {' '}
+        .
+      </Animated.Text>
     );
 
-    return (
-      <Text style={this.props.style}>
-        {dots}
-      </Text>
-    );
+    return <View style={styles.container}>{dots}</View>
+
+    // return (
+    //   <Text style={this.props.style}>
+    //     {dots}
+    //   </Text>
+    // );
   }
 }
 
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row'
+  }
+});

--- a/src/AnimatedEllipsis.js
+++ b/src/AnimatedEllipsis.js
@@ -78,12 +78,6 @@ export default class AnimatedEllipsis extends Component {
     );
 
     return <View style={styles.container}>{dots}</View>
-
-    // return (
-    //   <Text style={this.props.style}>
-    //     {dots}
-    //   </Text>
-    // );
   }
 }
 


### PR DESCRIPTION
Hey @BaseCase, I applied a fix for the following issue:

https://github.com/adorableio/react-native-animated-ellipsis/issues/5

The fix is based on the one provided by @tangnv here: 

https://github.com/adorableio/react-native-animated-ellipsis/issues/5#issuecomment-419861129

I also change the npm `postinstall`script to work off the `prepare` hook, as `postinstall` is outdated and won't work with direct installs github. `prepare` should work with both, see here: 

https://github.com/npm/npm/issues/3055#issuecomment-304698029
