### PR TITLE
Fix warning in RN 0.62.0+

### DIFF
--- a/src/AnimatedEllipsis.js
+++ b/src/AnimatedEllipsis.js
@@ -66,6 +66,7 @@ export default class AnimatedEllipsis extends Component {
     Animated.timing(this._animation_state.dot_opacities[which_dot], {
       toValue: this._animation_state.target_opacity,
       duration: this.props.animationDelay,
+      useNativeDriver: false,
     }).start(this.animate_dots.bind(this, next_dot));
   }
 


### PR DESCRIPTION
As of [React Native 0.62.0](https://reactnative.dev/blog/2020/03/26/version-0.62#deprecations), `nativeDriver` must always be set in `Animated`. 

Running this package in a RN 0.62.0+ app will result in the following error being show:
`Animated: 'useNativeDriver' was not specified. This is a required option and must be explicitly set to 'true' or 'false'`.

The question at this point, is whether it should be set to false, but I will leave that for you to decide. 

Closes #11 #15 