### PR TITLE
Added type definition file and useNativeDriver prop (default: false)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,6 @@
   "devDependencies": {
     "babel-cli": "^6.24.1",
     "babel-plugin-transform-react-jsx": "^6.24.1"
-  }
+  },
+  "types": "./src/AnimatedEllipsis.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple, customizable animated dots component for use in React Native apps. Ideal for loading screens.",
   "main": "dist/AnimatedEllipsis.js",
   "scripts": {
-    "build": "babel src/ -d dist",
+    "build": "babel src/ -d dist --copy-files",
     "prepare": "npm run build"
   },
   "author": "Casey Brant <casey@adorable.io>",
@@ -22,5 +22,5 @@
     "babel-cli": "^6.24.1",
     "babel-plugin-transform-react-jsx": "^6.24.1"
   },
-  "types": "./src/AnimatedEllipsis.d.ts"
+  "types": "dist/AnimatedEllipsis.d.ts"
 }

--- a/src/AnimatedEllipsis.d.ts
+++ b/src/AnimatedEllipsis.d.ts
@@ -1,0 +1,15 @@
+declare module 'react-native-animated-ellipsis' {
+    import { StyleProp, TextStyle } from 'react-native';
+
+    interface AnimatedEllipsisProps {
+        numberOfDots?: number;
+        animationDelay?: number;
+        minOpacity?: number;
+        style?: StyleProp<TextStyle>;
+        useNativeDriver?: boolean;
+    }
+
+    const AnimatedEllipsis: React.FC<AnimatedEllipsisProps>;
+
+    export default AnimatedEllipsis;
+}

--- a/src/AnimatedEllipsis.d.ts
+++ b/src/AnimatedEllipsis.d.ts
@@ -2,13 +2,31 @@ declare module 'react-native-animated-ellipsis' {
     import { StyleProp, TextStyle } from 'react-native';
 
     interface AnimatedEllipsisProps {
+        /**
+         * The number of dots you'd like to show. Defaults to 3.
+         */
         numberOfDots?: number;
+        /**
+         * The length in milliseconds of each phase of the animated. Defaults to 300.
+         */
         animationDelay?: number;
+        /**
+         * The minimum opacity for the dots. Defaults to 0.
+         */
         minOpacity?: number;
+        /**
+         * CSS to apply to the dots. It accepts any styles that a normal <Text /> component can take.
+         */
         style?: StyleProp<TextStyle>;
+        /**
+         * Whether to use the native driver for the animation. Defaults to false.
+         */
         useNativeDriver?: boolean;
     }
 
+    /**
+     * A simple, customizable animated dots component for use in React Native apps. Ideal for loading screens.
+     */
     const AnimatedEllipsis: React.FC<AnimatedEllipsisProps>;
 
     export default AnimatedEllipsis;

--- a/src/AnimatedEllipsis.js
+++ b/src/AnimatedEllipsis.js
@@ -9,6 +9,7 @@ export default class AnimatedEllipsis extends Component {
     animationDelay: PropTypes.number,
     minOpacity: PropTypes.number,
     style: Text.propTypes.style,
+    useNativeDriver: PropTypes.bool
   };
 
   static defaultProps = {
@@ -18,7 +19,8 @@ export default class AnimatedEllipsis extends Component {
     style: {
       color: '#aaa',
       fontSize: 32,
-    }
+    },
+    useNativeDriver: false
   };
 
   constructor(props) {
@@ -66,6 +68,7 @@ export default class AnimatedEllipsis extends Component {
     Animated.timing(this._animation_state.dot_opacities[which_dot], {
       toValue: this._animation_state.target_opacity,
       duration: this.props.animationDelay,
+      useNativeDriver: this.props.useNativeDriver
     }).start(this.animate_dots.bind(this, next_dot));
   }
 


### PR DESCRIPTION
### This PR implements the following:

- Adds type definitions.
- Adds prop descriptions.
- Adds a `useNativeDriver` prop that defaults to `FALSE`.

-------

I should have checked the existing PRs first (there are 2 others that implement a prop to enable the native Animation driver and it appears someone even forked the library and published to npm since the other PRs haven't been merged). Still going to submit this PR since it includes a type definition file and prop descriptions (although it's doing the bare minimum to get that to work).

If you want to use this fork without waiting on PR approval then remove your existing installation and install it from the fork:
```
npm remove react-native-animated-ellipsis
npm install https://github.com/RAMOhio/react-native-animated-ellipsis.git#master
```

Afterwards, your **package.json** should look like:
```
"dependencies": {
    ...
    "react-native-animated-ellipsis": "github:RAMOhio/react-native-animated-ellipsis#master",
    ...
  },
```
_(this concept will also work with the other forks, or forked npm packages in general)_

Examples:
```
// You can import the package as normal without specifying that it came from a GitHub fork, i.e.:
import AnimatedEllipsis from 'react-native-animated-ellipsis';

// ...

  // Using the native Animation driver.
  <AnimatedEllipsis
      useNativeDriver
  />


  // Not using the native Animation driver.
  <AnimatedEllipsis />

  // ...or:

  <AnimatedEllipsis
      useNativeDriver={false}
  />

// ...
```

Note: in case anyone doesn't already know, make sure to check back on PRs where you've done a package install directly from GitHub to ensure your libraries are always up to date. Unfortunately this library looks like it might no longer be maintained [ @adorableio ?]